### PR TITLE
Add support for listening for remote debugging connections

### DIFF
--- a/bin/fx-runner
+++ b/bin/fx-runner
@@ -13,7 +13,7 @@ program
   .option("--new-instance", "Use a new instance")
   .option("--no-remote", "Do not allow remote calls")
   .option("--foreground", "Bring Firefox to the fireground")
-
+  .option("-l, --listen <port>", "Start the debugger server on a specific port.")
 
 program
   .command("start")
@@ -26,7 +26,8 @@ program
       "new-instance": !!program.newInstance ? true : false,
       "foreground": !!program.foreground ? true : false,
       "no-remote": !program.remote ? true : false,
-      "binary-args": program.binaryArgs || ""
+      "binary-args": program.binaryArgs || "",
+      "listen": program.listen || 6000
     })
     .then(function(results) {
       var firefox = results.process;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/run');

--- a/lib/run.js
+++ b/lib/run.js
@@ -43,6 +43,11 @@ function runFirefox (options) {
   if (options["binary-args"]) {
     args.unshift( options["binary-args"] );
   }
+  // support for starting the remote debugger server
+  if (options["listen"]) {
+    args.unshift( options.listen );
+    args.unshift( "--start-debugger-server" );
+  }
 
   return normalizeBinary(options.binary).then(function(binary) {
     // Using `spawn` so we can stream logging as they come in, rather than buffer them up


### PR DESCRIPTION
I want to be able to write a single script that starts firefox with a remote debugging port open and then connects to it to do various things. This should help with that, although we still require that some prefs be flipped in the profile used ( devtools.debugger.remote-enabled and devtools.chrome.enabled )