### PR TITLE
Add support for multiple and compound binary arguments

### DIFF
--- a/bin/fx-runner
+++ b/bin/fx-runner
@@ -26,7 +26,7 @@ program
       "new-instance": !!program.newInstance ? true : false,
       "foreground": !!program.foreground ? true : false,
       "no-remote": !program.remote ? true : false,
-      "binary-args": program.binaryArgs || "",
+      "binary-args": (program.binaryArgs || "").split(" "),
       "listen": program.listen || 6000
     })
     .then(function(results) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -40,8 +40,8 @@ function runFirefox (options) {
   if (options["foreground"]) {
     args.unshift( "-foreground" );
   }
-  if (options["binary-args"]) {
-    args.unshift( options["binary-args"] );
+  if (options["binary-args"] && Array.isArray(options["binary-args"])) {
+    args = args.concat( options["binary-args"] );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {


### PR DESCRIPTION
@jsantell for Fx Hello I'd like to run Firefox with '-CreateProfile loop-dev', but with the current implementation that isn't possible.

Loop PR: mozilla/loop#59

I updated the source and tests a bit to accommodate for this and also support passing multiple additional arguments to the binary.