### PR TITLE
Use which to detect binary location on linux

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,7 @@ var path = require("path");
 var os = require("os");
 var Winreg = require('winreg');
 var when = require("when");
+var which = require("when/node").lift(require("which"));
 
 /**
  * Takes a path to a binary file (like `/Applications/FirefoxNightly.app`)
@@ -31,48 +32,46 @@ function normalizeBinary (binaryPath, platform, arch) {
                /linux/i.test(platform) ? "linux" + arch :
                platform;
 
-    var channelNames = ["firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"];
-
     var app = binaryPath.toLowerCase();
-    var result = null;
-    if (platform === "osx" && channelNames.indexOf(binaryPath) !== -1) {
-      // Try to find the app for this channel.
-      // mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.firefoxdeveloperedition'"
-      var results = spawnSync("mdfind", ["kMDItemCFBundleIdentifier == 'org.mozilla." + binaryPath + "'"]);
-      if (results.stdout) {
-        result = results.stdout.toString().split('\n')[0];
+
+    if (platform === "osx") {
+      var result = null;
+      var channelNames = ["firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"];
+
+      if (channelNames.indexOf(binaryPath) !== -1) {
+        // Try to find the app for this channel.
+        // mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.firefoxdeveloperedition'"
+        var results = spawnSync("mdfind", ["kMDItemCFBundleIdentifier == 'org.mozilla." + binaryPath + "'"]);
+        if (results.stdout) {
+          result = results.stdout.toString().split('\n')[0];
+        }
       }
+      binaryPath = result ||
+                   normalizeBinary.paths[app + " on " + platform] ||
+                   binaryPath;
+      var isAppPath = path.extname(binaryPath) === ".app";
+
+      // On OSX, if given the app path, resolve to the actual binary
+      binaryPath = isAppPath ? path.join(binaryPath, "Contents/MacOS/firefox-bin") :
+                   binaryPath;
+
+      return resolve(binaryPath);
     }
-    binaryPath = result ||
-                 normalizeBinary.paths[app + " on " + platform] ||
-                 normalizeBinary.paths[app + " on " + platform + arch] ||
-                 binaryPath;
-
-    var isAppPath = platform === "osx" && path.extname(binaryPath) === ".app";
-
-    // On OSX, if given the app path, resolve to the actual binary
-    binaryPath = isAppPath ? path.join(binaryPath, "Contents/MacOS/firefox-bin") :
-                 binaryPath;
-    // not Windows or binary path given
-    if (platform.indexOf("windows") === -1 || channelNames.indexOf(app) === -1) {
+    // Return the path if it contains at least two segments
+    else if (binaryPath.indexOf(path.sep) !== -1) {
+      return resolve(binaryPath);
+    }
+    // On linux but no path yet, use which to try and find the binary
+    else if (platform.indexOf("linux") !== -1) {
+        binaryPath = normalizeBinary.appNames[binaryPath + " on linux"] || binaryPath;
+        return resolve(which(binaryPath));
+    }
+    // No action needed on windows if it's an executable already
+    else if(path.extname(binaryPath) === ".exe") {
       return resolve(binaryPath);
     }
     // Windows binary finding
-    var appName = "Mozilla Firefox";
-    switch(app) {
-      case "beta":
-        // the default path in the beta installer is the same as the stable one
-        appName = "Mozilla Firefox";
-        break;
-      case "aurora":
-        appName = "Aurora";
-        break;
-      case "nightly":
-        appName = "Nightly";
-        break;
-      default:
-        break;
-    }
+    var appName = normalizeBinary.appNames[app + " on windows"];
 
     // this is used when reading the registry goes wrong.
     function fallBack () {
@@ -119,16 +118,18 @@ normalizeBinary.paths = {
   "firefoxdeveloperedition on osx": "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin",
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
-
-  "firefox on linux": "/usr/lib/firefox",
-  "beta on linux": "/usr/lib/firefox-beta",
-  "aurora on linux": "/usr/lib/firefox-aurora",
-  "nightly on linux": "/usr/lib/firefox-nightly",
-
-  "firefox on linux(64)": "/usr/lib64/firefox",
-  "beta on linux(64)": "/usr/lib64/firefox-beta",
-  "aurora on linux(64)": "/usr/lib64/firefox-aurora",
-  "nightly on linux(64)" : "/usr/lib64/firefox-nightly"
 };
+
+normalizeBinary.appNames = {
+  "firefox on linux": "firefox",
+  "beta on linux": "firefox-beta",
+  "aurora on linux": "firefox-aurora",
+  "nightly on linux": "firefox-nightly",
+  "firefox on windows": "Mozilla Firefox",
+  // the default path in the beta installer is the same as the stable one
+  "beta on windows": "Mozilla Firefox",
+  "aurora on windows": "Aurora",
+  "nightly on windows": "Nightly"
+}
 
 exports.normalizeBinary = normalizeBinary;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "3.10.1",
     "spawn-sync": "1.0.15",
     "when": "3.7.2",
+    "which": "^1.2.4",
     "winreg": "0.0.12"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "3.10.1",
     "spawn-sync": "1.0.15",
     "when": "3.7.2",
-    "which": "^1.2.4",
+    "which": "1.2.4",
     "winreg": "0.0.12"
   },
   "devDependencies": {

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -179,7 +179,7 @@ describe("lib/utils", function () {
     all(promises).then(done.bind(null, null), done);
   });
 
-  it("normalizeBinary() notmalizes special names like: firefox, nightly, etc... on Linux", function(done) {
+  it("normalizeBinary() normalizes special names like: firefox, nightly, etc... on Linux", function(done) {
     var args = 0;
     var expected = 1;
 


### PR DESCRIPTION
This should behave the same as it already does, just even better on linux. Instead of fixed path mappings it just uses binary name mappings. If a platform uses a different name, like Ubuntu uses `firefox-trunk` for Nightly that will still work, since which is invoked if the binaryPath does not contain a directory separator. I've also regrouped some of the logic to only affect the necessary code paths.

This should fix #2 