### PR TITLE
Add node 4 and 5 instead of iojs to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "iojs"
   - "0.10"
   - "0.12"
+  - "4"
+  - "5"


### PR DESCRIPTION
Run tests on travis on the same platforms as jpm. Most notably instead of io.js run them on node.js version 4 and 5.