### PR TITLE
Use mdfind to find the locations of the apps on OS X.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+var spawnSync = require("spawn-sync");
 var path = require("path");
 var os = require("os");
 var Winreg = require('winreg');
@@ -30,8 +31,20 @@ function normalizeBinary (binaryPath, platform, arch) {
                /linux/i.test(platform) ? "linux" + arch :
                platform;
 
+    var channelNames = ["firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"];
+
     var app = binaryPath.toLowerCase();
-    binaryPath = normalizeBinary.paths[app + " on " + platform] ||
+    var result = null;
+    if (platform === "osx" && channelNames.indexOf(binaryPath) !== -1) {
+      // Try to find the app for this channel.
+      // mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.firefoxdeveloperedition'"
+      var results = spawnSync("mdfind", ["kMDItemCFBundleIdentifier == 'org.mozilla." + binaryPath + "'"]);
+      if (results.stdout) {
+        result = results.stdout.toString().split('\n')[0];
+      }
+    }
+    binaryPath = result ||
+                 normalizeBinary.paths[app + " on " + platform] ||
                  normalizeBinary.paths[app + " on " + platform + arch] ||
                  binaryPath;
 
@@ -40,7 +53,6 @@ function normalizeBinary (binaryPath, platform, arch) {
     // On OSX, if given the app path, resolve to the actual binary
     binaryPath = isAppPath ? path.join(binaryPath, "Contents/MacOS/firefox-bin") :
                  binaryPath;
-    var channelNames = ["firefox", "beta", "nightly", "aurora"];
     // not Windows or binary path given
     if (platform.indexOf("windows") === -1 || channelNames.indexOf(app) === -1) {
       return resolve(binaryPath);
@@ -104,6 +116,7 @@ function normalizeBinary (binaryPath, platform, arch) {
 normalizeBinary.paths = {
   "firefox on osx": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
   "beta on osx": "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin",
+  "firefoxdeveloperedition on osx": "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin",
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "commander": "2.9.0",
     "fs-promise": "0.3.1",
     "lodash": "3.10.1",
+    "spawn-sync": "1.0.15",
     "when": "3.7.2",
     "winreg": "0.0.12"
   },

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -170,6 +170,9 @@ describe("lib/utils", function () {
       [["beta", "linux", "x86"], "/usr/lib/firefox-beta"],
       [["beta", "linux", "x86_64"], "/usr/lib64/firefox-beta"],
 
+      [["firefoxdeveloperedition", "darwin", "x86"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
+      [["firefoxdeveloperedition", "darwin", "x86_64"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
+
       [["aurora", "darwin", "x86"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
       [["aurora", "darwin", "x86_64"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
       [["aurora", "linux", "x86"], "/usr/lib/firefox-aurora"],


### PR DESCRIPTION
(I keep my Firefoxen in `/Applications/Local` because I hate myself apparently.  This patch lets me run firefox without specifying the full path all over the place.  Oh, and it adds `firefoxdeveloperedition` as a target, cause everyone loves the Developer Edition!  😃)