### PR TITLE
Prefer the official app per channel on OS X

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-var spawnSync = require("spawn-sync");
+var defaultSpawnSync = require("spawn-sync");
 var path = require("path");
 var os = require("os");
 var Winreg = require('winreg');
@@ -39,12 +39,7 @@ function normalizeBinary (binaryPath, platform, arch) {
       var channelNames = ["firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"];
 
       if (channelNames.indexOf(binaryPath) !== -1) {
-        // Try to find the app for this channel.
-        // mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.firefoxdeveloperedition'"
-        var results = spawnSync("mdfind", ["kMDItemCFBundleIdentifier == 'org.mozilla." + binaryPath + "'"]);
-        if (results.stdout) {
-          result = results.stdout.toString().split('\n')[0];
-        }
+        result = findMacAppByChannel(binaryPath);
       }
       binaryPath = result ||
                    normalizeBinary.paths[app + " on " + platform] ||
@@ -133,3 +128,31 @@ normalizeBinary.appNames = {
 }
 
 exports.normalizeBinary = normalizeBinary;
+
+function findMacAppByChannel(channel, opt) {
+  // Try to find an installed app on Mac OS X for this channel.
+  opt = opt || {
+    spawnSync: defaultSpawnSync,
+  };
+  // Example: mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.nightly'"
+  var results = opt.spawnSync("mdfind", ["kMDItemCFBundleIdentifier == 'org.mozilla." + channel + "'"]);
+  var result = null;
+  if (results.stdout) {
+    var allMatches = results.stdout.toString().split('\n');
+    var officialApp = allMatches.filter(function(path) {
+      // Prefer the one installed in the official app location:
+      return path.indexOf("/Applications/") === 0;
+    })[0];
+
+    if (officialApp) {
+      result = officialApp;
+    } else {
+      // Fall back to the first mdfind match.
+      result = allMatches[0];
+    }
+  }
+
+  return result;
+}
+
+exports.findMacAppByChannel = findMacAppByChannel;

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -197,7 +197,7 @@ describe("lib/utils", function () {
 
       [["beta", "linux", "x86"], "/usr/bin/firefox-beta"],
       [["beta", "linux", "x86_64"], "/usr/bin/firefox-beta"],
-      
+
       [["aurora", "linux", "x86"], "/usr/bin/firefox-aurora"],
       [["aurora", "linux", "x86_64"], "/usr/bin/firefox-aurora"],
 
@@ -238,5 +238,47 @@ describe("lib/utils", function () {
       });
     });
     all(promises).then(done.bind(null, null), done);
+  });
+
+  describe("findMacAppByChannel", function() {
+
+    var defaultNightly = "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin";
+
+    function spawnSyncStub(stdout) {
+      return function() {
+        return {stdout: stdout};
+      }
+    }
+
+    it("returns false when no app is found", function() {
+      var result = utils.findMacAppByChannel("nightly", {spawnSync: spawnSyncStub("")});
+      expect(result).to.be.equal(null);
+    });
+
+    it("returns sole app result", function() {
+      var result = utils.findMacAppByChannel("nightly", {
+        spawnSync: spawnSyncStub(defaultNightly + "\n"),
+      });
+      expect(result).to.be.equal(defaultNightly);
+    });
+
+    it("prefers to find the default app", function() {
+      var result = utils.findMacAppByChannel("nightly", {
+        spawnSync: spawnSyncStub([
+          "/src/mozilla-central/Nightly.app/Contents/MacOS/firefox-bin",
+          defaultNightly,
+        ].join("\n")),
+      });
+      expect(result).to.be.equal(defaultNightly);
+    });
+
+    it("falls back to the first app result", function() {
+      var randomApp = "/src/mozilla-central/Nightly.app/Contents/MacOS/firefox-bin";
+      var result = utils.findMacAppByChannel("nightly", {
+        spawnSync: spawnSyncStub(randomApp + "\n"),
+      });
+      expect(result).to.be.equal(randomApp);
+    });
+
   });
 });


### PR DESCRIPTION
Since I have a custom build of Firefox, mdfind returns this:

````
$ mdfind "kMDItemCFBundleIdentifier == 'org.mozilla.nightly'"
/Users/kumar/src/fx-team/objdir-frontend/dist/Nightly.app
/Applications/FirefoxNightly.app
````
It should only find the official nightly app