### PR TITLE
Fix unrecognized command line flag --start-debugger-server on Windows

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -46,7 +46,7 @@ function runFirefox (options) {
   // support for starting the remote debugger server
   if (options["listen"]) {
     args.unshift( options.listen );
-    args.unshift( "--start-debugger-server" );
+    args.unshift( "-start-debugger-server" );
   }
 
   return normalizeBinary(options.binary).then(function(binary) {

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -104,7 +104,7 @@ describe("fx-runner start", function () {
       var proc = exec("start -v -b " + fakeBinary + " --listen 6666", {}, function (err, stdout, stderr) {
         expect(err).to.not.be.ok;
         expect(stderr).to.not.be.ok;
-        expect(stdout).to.contain("--start-debugger-server");
+        expect(stdout).to.contain("-start-debugger-server");
         expect(stdout).to.contain("6666");
         expect(stdout).to.not.contain("--listen");
         expect(stdout).to.not.contain("-P");


### PR DESCRIPTION
This PR remove a dash from the `start-debugger-server` command line flag, because `--start-debugger-server` is not recognized by the Firefox executable on Windows systems, and on the contrary `-start-debugger-server` works as expected on all the supported platforms.

The above is the reason of mozilla/web-ext#317 on windows, which is not a Firewall issue and it will be fixed once we release an updated fx-runner npm package and update the dependency in webe-ext accordingly.