### PR TITLE
Fix binary args to be splitted to array in lib/run.js instead of bin/fx-runner

### DIFF
--- a/bin/fx-runner
+++ b/bin/fx-runner
@@ -26,7 +26,7 @@ program
       "new-instance": !!program.newInstance ? true : false,
       "foreground": !!program.foreground ? true : false,
       "no-remote": !program.remote ? true : false,
-      "binary-args": (program.binaryArgs || "").split(" "),
+      "binary-args": program.binaryArgs || "",
       "listen": program.listen || 6000
     })
     .then(function(results) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ function runFirefox (options) {
     args.unshift( "-foreground" );
   }
   if (options["binary-args"]) {
-    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\"[^"]*\\"|\\")*"|[^\s]+/g) );
+    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\")*"|[^\s]+/g) );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -40,8 +40,8 @@ function runFirefox (options) {
   if (options["foreground"]) {
     args.unshift( "-foreground" );
   }
-  if (options["binary-args"] && Array.isArray(options["binary-args"])) {
-    args = args.concat( options["binary-args"] );
+  if (options["binary-args"]) {
+    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\"[^"]*\\")*"|[^"\s]+/g) );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ function runFirefox (options) {
     args.unshift( "-foreground" );
   }
   if (options["binary-args"]) {
-    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\")*"|[^\s]+/g) );
+    args = args.concat( options["binary-args"].match(/\"(?:[^"]|\\\")*\"|(?:[^"\s]|\")+/g) );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ function runFirefox (options) {
     args.unshift( "-foreground" );
   }
   if (options["binary-args"]) {
-    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\"[^"]*\\")*"|[^"\s]+/g) );
+    args = args.concat( options["binary-args"].match(/"(?:[^"\\]|\\(?!")|\\"[^"]*\\"|\\")*"|[^\s]+/g) );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {


### PR DESCRIPTION
Fix [#10](https://github.com/mozilla-jetpack/node-fx-runner/issues/10)

Then failure in [Update dependencies to remove deprecation warnings by toonetown · Pull Request #534 · mozilla-jetpack/jpm](https://github.com/mozilla-jetpack/jpm/pull/534) should be fixed too, I hope.