### PR TITLE
Split binary-args in lib/run.js

### DIFF
--- a/bin/fx-runner
+++ b/bin/fx-runner
@@ -26,7 +26,7 @@ program
       "new-instance": !!program.newInstance ? true : false,
       "foreground": !!program.foreground ? true : false,
       "no-remote": !program.remote ? true : false,
-      "binary-args": (program.binaryArgs || "").split(" "),
+      "binary-args": program.binaryArgs || "",
       "listen": program.listen || 6000
     })
     .then(function(results) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -7,6 +7,7 @@ var spawn = require("child_process").spawn;
 var defer = require("when").defer;
 var extend = require("lodash").extend;
 var normalizeBinary = require("./utils").normalizeBinary;
+var parse = require("shell-quote").parse;
 
 /**
  * Takes a manifest object (from package.json) and options,
@@ -41,7 +42,12 @@ function runFirefox (options) {
     args.unshift( "-foreground" );
   }
   if (options["binary-args"]) {
-    args = concatBinArgs(args, options["binary-args"]);
+    if (Array.isArray(options["binary-args"])) {
+      args = args.concat(options["binary-args"]);
+    }
+    else {
+      args = args.concat(parse(options["binary-args"]));
+    }
   }
   // support for starting the remote debugger server
   if (options["listen"]) {
@@ -82,23 +88,3 @@ function isProfileName (profile) {
   }
   return !/[\\\/]/.test(profile);
 }
-
-/**
- * Concat binary arguments to arguments array.
- *
- * @param {Array} args - arguments
- * @param {string|Array} binArgs - binary arguments
- * @return {Array} - arguments
- */
-function concatBinArgs (args, binArgs) {
-  var removeQuotes = function (arg) {
-    var quotedArg = /^\s*(?:"(.*)"|'(.*)')\s*$/.exec(arg);
-    return quotedArg ? (quotedArg[1] || quotedArg[2]) : arg;
-  };
-  args = Array.isArray(args) ? args : [];
-  if (typeof binArgs === "string" || binArgs instanceof String) {
-    binArgs = binArgs.match(/(?:^|\s)(?:\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\')(?=\s|$)|(?:[^"'\s]|\"|\')+/g);
-  }
-  return Array.isArray(binArgs) ? args.concat(binArgs.map(removeQuotes)) : args;
-}
-module.exports.concatBinArgs = concatBinArgs;

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,10 +91,18 @@ function isProfileName (profile) {
  * @return {Array} - arguments
  */
 function concatBinArgs (args, binArgs) {
-  args = Array.isArray(args) && args || [];
+  args = Array.isArray(args) ? args : [];
   if (typeof binArgs === "string" || binArgs instanceof String) {
-    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|(?:[^"\s]|\")+/g);
+    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\'|(?:[^"'\s]|\"\')+/g);
+    if (binArgs) {
+      for (var arg, i = 0, l = binArgs.length; i < l; i++) {
+        arg = (/^"(.*)"$/.exec(binArgs[i]) || /^'(.*)'$/.exec(binArgs[i]));
+        if (arg) {
+          binArgs[i] = arg[1];
+        }
+      }
+    }
   }
-  return Array.isArray(binArgs) && args.concat(binArgs) || args;
+  return Array.isArray(binArgs) ? args.concat(binArgs) : args;
 }
 module.exports.concatBinArgs = concatBinArgs;

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,14 +91,14 @@ function isProfileName (profile) {
  * @return {Array} - arguments
  */
 function concatBinArgs (args, binArgs) {
-  var remQuotes = function (arg) {
-    var quotedStr = /^"(.*)"$/.exec(arg) || /^'(.*)'$/.exec(arg);
-    return quotedStr ? quotedStr[1] : arg;
+  var removeQuotes = function (arg) {
+    var quotedArg = /^\s*(?:"(.*)"|'(.*)')\s*$/.exec(arg);
+    return quotedArg ? (quotedArg[1] || quotedArg[2]) : arg;
   };
   args = Array.isArray(args) ? args : [];
   if (typeof binArgs === "string" || binArgs instanceof String) {
-    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\'|(?:[^"'\s]|\"|\')+/g);
+    binArgs = binArgs.match(/(?:^|\s)(?:\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\')(?=\s|$)|(?:[^"'\s]|\"|\')+/g);
   }
-  return Array.isArray(binArgs) ? args.concat(binArgs.map(remQuotes)) : args;
+  return Array.isArray(binArgs) ? args.concat(binArgs.map(removeQuotes)) : args;
 }
 module.exports.concatBinArgs = concatBinArgs;

--- a/lib/run.js
+++ b/lib/run.js
@@ -40,8 +40,8 @@ function runFirefox (options) {
   if (options["foreground"]) {
     args.unshift( "-foreground" );
   }
-  if (options["binary-args"] && Array.isArray(options["binary-args"])) {
-    args = args.concat( options["binary-args"] );
+  if (options["binary-args"]) {
+    args = args.concat( options["binary-args"].match(/\"(?:[^"]|\\\")*\"|(?:[^"\s]|\")+/g) );
   }
   // support for starting the remote debugger server
   if (options["listen"]) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -41,7 +41,7 @@ function runFirefox (options) {
     args.unshift( "-foreground" );
   }
   if (options["binary-args"]) {
-    args = args.concat( options["binary-args"].match(/\"(?:[^"]|\\\")*\"|(?:[^"\s]|\")+/g) );
+    args = concatBinArgs(args, options["binary-args"]);
   }
   // support for starting the remote debugger server
   if (options["listen"]) {
@@ -82,3 +82,19 @@ function isProfileName (profile) {
   }
   return !/[\\\/]/.test(profile);
 }
+
+/**
+ * Concat binary arguments to arguments array.
+ *
+ * @param {Array} args - arguments
+ * @param {string|Array} binArgs - binary arguments
+ * @return {Array} - arguments
+ */
+function concatBinArgs (args, binArgs) {
+  args = Array.isArray(args) && args || [];
+  if (typeof binArgs === "string" || binArgs instanceof String) {
+    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|(?:[^"\s]|\")+/g);
+  }
+  return Array.isArray(binArgs) && args.concat(binArgs) || args;
+}
+module.exports.concatBinArgs = concatBinArgs;

--- a/lib/run.js
+++ b/lib/run.js
@@ -91,18 +91,14 @@ function isProfileName (profile) {
  * @return {Array} - arguments
  */
 function concatBinArgs (args, binArgs) {
+  var remQuotes = function (arg) {
+    var quotedStr = /^"(.*)"$/.exec(arg) || /^'(.*)'$/.exec(arg);
+    return quotedStr ? quotedStr[1] : arg;
+  };
   args = Array.isArray(args) ? args : [];
   if (typeof binArgs === "string" || binArgs instanceof String) {
-    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\'|(?:[^"'\s]|\"\')+/g);
-    if (binArgs) {
-      for (var arg, i = 0, l = binArgs.length; i < l; i++) {
-        arg = (/^"(.*)"$/.exec(binArgs[i]) || /^'(.*)'$/.exec(binArgs[i]));
-        if (arg) {
-          binArgs[i] = arg[1];
-        }
-      }
-    }
+    binArgs = binArgs.match(/\"(?:[^"]|\\\")*\"|\'(?:[^']|\\\')*\'|(?:[^"'\s]|\"|\')+/g);
   }
-  return Array.isArray(binArgs) ? args.concat(binArgs) : args;
+  return Array.isArray(binArgs) ? args.concat(binArgs.map(remQuotes)) : args;
 }
 module.exports.concatBinArgs = concatBinArgs;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "commander": "2.9.0",
     "fs-promise": "0.3.1",
     "lodash": "3.10.1",
+    "shell-quote": "1.6.1",
     "spawn-sync": "1.0.15",
     "when": "3.7.7",
     "which": "1.2.4",

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -13,7 +13,6 @@ var exec = utils.exec;
 var isWindows = /^win/.test(process.platform);
 var normalizeBinary = require("../../lib/utils").normalizeBinary;
 var cp = require("child_process");
-var concatBinArgs = require("../../lib/run").concatBinArgs;
 
 var fakeBinary = path.join(__dirname, "..", "utils", "dummybinary" +
   (isWindows ? ".bat" : ".sh"));
@@ -114,23 +113,5 @@ describe("fx-runner start", function () {
         done();
       });
     });
-  });
-});
-
-describe("concat binary arguments", function () {
-  it("concats binary arguments from a string", function () {
-    var arr = concatBinArgs([], "-a b -c \"d e\"");
-    expect(arr[0]).to.be.equal("-a");
-    expect(arr[1]).to.be.equal("b");
-    expect(arr[2]).to.be.equal("-c");
-    expect(arr[3]).to.be.equal("d e");
-  });
-
-  it("concats binary arguments from an array", function () {
-    var arr = concatBinArgs([], ["-a", "b", "-c", "d e"]);
-    expect(arr[0]).to.be.equal("-a");
-    expect(arr[1]).to.be.equal("b");
-    expect(arr[2]).to.be.equal("-c");
-    expect(arr[3]).to.be.equal("d e");
   });
 });

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -118,21 +118,19 @@ describe("fx-runner start", function () {
 });
 
 describe("concat binary arguments", function () {
-  it("binary arguments as string", function (done) {
+  it("concats binary arguments from a string", function () {
     var arr = concatBinArgs([], "-a b -c \"d e\"");
     expect(arr[0]).to.be.equal("-a");
     expect(arr[1]).to.be.equal("b");
     expect(arr[2]).to.be.equal("-c");
-    expect(arr[3]).to.be.equal("\"d e\"");
-    done();
+    expect(arr[3]).to.be.equal("d e");
   });
 
-  it("binary arguments as array", function (done) {
-    var arr = concatBinArgs([], ["-a", "b", "-c", "\"d e\""]);
+  it("concats binary arguments from an array", function () {
+    var arr = concatBinArgs([], ["-a", "b", "-c", "d e"]);
     expect(arr[0]).to.be.equal("-a");
     expect(arr[1]).to.be.equal("b");
     expect(arr[2]).to.be.equal("-c");
-    expect(arr[3]).to.be.equal("\"d e\"");
-    done();
+    expect(arr[3]).to.be.equal("d e");
   });
 });

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -13,6 +13,7 @@ var exec = utils.exec;
 var isWindows = /^win/.test(process.platform);
 var normalizeBinary = require("../../lib/utils").normalizeBinary;
 var cp = require("child_process");
+var concatBinArgs = require("../../lib/run").concatBinArgs;
 
 var fakeBinary = path.join(__dirname, "..", "utils", "dummybinary" +
   (isWindows ? ".bat" : ".sh"));
@@ -113,5 +114,25 @@ describe("fx-runner start", function () {
         done();
       });
     });
+  });
+});
+
+describe("concat binary arguments", function () {
+  it("binary arguments as string", function (done) {
+    var arr = concatBinArgs([], "-a b -c \"d e\"");
+    expect(arr[0]).to.be.equal("-a");
+    expect(arr[1]).to.be.equal("b");
+    expect(arr[2]).to.be.equal("-c");
+    expect(arr[3]).to.be.equal("\"d e\"");
+    done();
+  });
+
+  it("binary arguments as array", function (done) {
+    var arr = concatBinArgs([], ["-a", "b", "-c", "\"d e\""]);
+    expect(arr[0]).to.be.equal("-a");
+    expect(arr[1]).to.be.equal("b");
+    expect(arr[2]).to.be.equal("-c");
+    expect(arr[3]).to.be.equal("\"d e\"");
+    done();
   });
 });

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -13,6 +13,7 @@ var exec = utils.exec;
 var isWindows = /^win/.test(process.platform);
 var normalizeBinary = require("../../lib/utils").normalizeBinary;
 var cp = require("child_process");
+var parse = require("shell-quote").parse;
 
 var fakeBinary = path.join(__dirname, "..", "utils", "dummybinary" +
   (isWindows ? ".bat" : ".sh"));
@@ -113,5 +114,15 @@ describe("fx-runner start", function () {
         done();
       });
     });
+  });
+});
+
+describe("concat binary arguments", function () {
+  it("concats binary arguments from a string", function () {
+    var arr = parse("-a b -c \"d e\"");
+    expect(arr[0]).to.be.equal("-a");
+    expect(arr[1]).to.be.equal("b");
+    expect(arr[2]).to.be.equal("-c");
+    expect(arr[3]).to.be.equal("d e");
   });
 });


### PR DESCRIPTION
Fix [Several arguments in --binary-args doesn't work when used in jpm run command. · Issue #10](https://github.com/mozilla-jetpack/node-fx-runner/issues/10)

Split `binary-args` string into an array and concats to the `args` array.
Spaces are left as they are if the argument is quoted.
e.g. `"-a b -c \"d e\""` will concat `["-a", "b", "-c", "\"d e\""]`
