### PR TITLE
Handle case where key is null on Win32

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,7 +91,8 @@ function normalizeBinary (binaryPath, platform, arch) {
         key: rootKey
       });
       versionKey.get("CurrentVersion", function(err, key) {
-        return err ? reject() : resolve(key.value);
+        var isOk = key && !err;
+        return isOk ? resolve(key.value) : reject();
       });
     }).then(function(version) {
       var mainKey = new Winreg({


### PR DESCRIPTION
Might fix https://github.com/mozilla-jetpack/node-fx-runner/issues/26