### PR TITLE
Remove unused `fs-promise` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "MPL-2.0",
   "dependencies": {
     "commander": "2.9.0",
-    "fs-promise": "0.3.1",
     "lodash": "3.10.1",
     "shell-quote": "1.6.1",
     "spawn-sync": "1.0.15",

--- a/test/run/test.run.js
+++ b/test/run/test.run.js
@@ -4,7 +4,6 @@
 "use strict";
 
 var when = require("when");
-var fs = require("fs-promise");
 var path = require("path");
 var utils = require("../utils");
 var chai = require("chai");


### PR DESCRIPTION
It's deprecated, but not actually used anywhere, so now dependents won't see
warnings like (upon `npm install`):

    npm WARN deprecated fs-promise@0.3.1: Use mz or fs-extra^3.0 with Promise Support

or (upon `yarn install`):

    warning web-ext > fx-runner > fs-promise@0.3.1: Use mz or fs-extra^3.0 with Promise Support

