### PR TITLE
Support Firefox 64-bit on Windows 64-bit as default

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,15 +74,13 @@ function normalizeBinary (binaryPath, platform, arch) {
     function fallBack () {
       var programFilesVar = "ProgramFiles";
       if (arch === "(64)") {
+        console.warn("You are using 32-bit version of Firefox on 64-bit versions of the Windows.\nSome features may not work correctly in this version. You should upgrade Firefox to the latest 64-bit version now!")
         programFilesVar = "ProgramFiles(x86)";
       }
       resolve(path.join(process.env[programFilesVar], appName, "firefox.exe"));
     }
 
     var rootKey = "\\Software\\Mozilla\\";
-    if (arch === "(64)") {
-      rootKey = "\\Software\\Wow6432Node\\Mozilla";
-    }
     rootKey = path.join(rootKey, appName);
 
     return when.promise(function(resolve, reject) {


### PR DESCRIPTION
Support Firefox 64-bit on Windows 64-bit as default and fallback to Firefox 32-bit.

See https://github.com/mozilla/web-ext/issues/213