### PR TITLE
Implement the firefoxdeveloperedition alias for Windows.  Fixes #28

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,6 +124,7 @@ normalizeBinary.appNames = {
   "firefox on windows": "Mozilla Firefox",
   // the default path in the beta installer is the same as the stable one
   "beta on windows": "Mozilla Firefox",
+  "firefoxdeveloperedition on windows": "Firefox Developer Edition",
   "aurora on windows": "Aurora",
   "nightly on windows": "Nightly"
 };


### PR DESCRIPTION
Completely untested