### PR TITLE
fix: Updated lodash to version 4.17.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "commander": "2.9.0",
-    "lodash": "3.10.1",
+    "lodash": "4.17.10",
     "shell-quote": "1.6.1",
     "spawn-sync": "1.0.15",
     "when": "3.7.7",


### PR DESCRIPTION
This pull request updates the lodash npm dependencies to version 4.17.10 (which fixes a vulnerability detected by nsp and npm audit: 

- https://nodesecurity.io/advisories/577

Looking at the above advisories it doesn't seem that node-fx-runner would actually be vulnerable, nevertheless this is detected by the security checks which are usually executed by the travis jobs of the projects that depends on this npm package and it makes these travis job to fail before any test has been actually been executed (e.g. https://travis-ci.org/mozilla/web-ext/jobs/380347430#L2046).