### PR TITLE
Add firefoxdeveloperedition alias on Linux

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -120,6 +120,7 @@ normalizeBinary.appNames = {
   "firefox on linux": "firefox",
   "beta on linux": "firefox-beta",
   "aurora on linux": "firefox-aurora",
+  "firefoxdeveloperedition on linux": "firefox-developer-edition",
   "nightly on linux": "firefox-nightly",
   "firefox on windows": "Mozilla Firefox",
   // the default path in the beta installer is the same as the stable one

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,6 +25,9 @@ function normalizeBinary (binaryPath, platform, arch) {
     platform = platform || os.platform();
     arch = arch || os.arch();
     binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY || "firefox";
+    if (binaryPath === "firefoxdeveloperedition") {
+      binaryPath = "deved";
+    }
 
     arch = /64/.test(arch) ? "(64)" : "";
     platform = /darwin/i.test(platform) ? "osx" :
@@ -37,7 +40,7 @@ function normalizeBinary (binaryPath, platform, arch) {
     if (platform === "osx") {
       var result = null;
       var channelNames = [
-        "firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"
+        "firefox", "deved", "beta", "nightly", "aurora"
       ];
 
       if (channelNames.indexOf(binaryPath) !== -1) {
@@ -111,7 +114,7 @@ function normalizeBinary (binaryPath, platform, arch) {
 normalizeBinary.paths = {
   "firefox on osx": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
   "beta on osx": "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin",
-  "firefoxdeveloperedition on osx": "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin",
+  "deved on osx": "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin",
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
   "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
 };
@@ -120,12 +123,12 @@ normalizeBinary.appNames = {
   "firefox on linux": "firefox",
   "beta on linux": "firefox-beta",
   "aurora on linux": "firefox-aurora",
-  "firefoxdeveloperedition on linux": "firefox-developer-edition",
+  "deved on linux": "firefox-developer-edition",
   "nightly on linux": "firefox-nightly",
   "firefox on windows": "Mozilla Firefox",
   // the default path in the beta installer is the same as the stable one
   "beta on windows": "Mozilla Firefox",
-  "firefoxdeveloperedition on windows": "Firefox Developer Edition",
+  "deved on windows": "Firefox Developer Edition",
   "aurora on windows": "Aurora",
   "nightly on windows": "Nightly"
 };

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -201,6 +201,9 @@ describe("lib/utils", function () {
       [["aurora", "linux", "x86"], "/usr/bin/firefox-aurora"],
       [["aurora", "linux", "x86_64"], "/usr/bin/firefox-aurora"],
 
+      [["firefoxdeveloperedition", "linux", "x86"], "/usr/bin/firefox-developer-edition"],
+      [["firefoxdeveloperedition", "linux", "x86_64"], "/usr/bin/firefox-developer-edition"],
+
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
     ].map(function(fixture) {

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -201,8 +201,8 @@ describe("lib/utils", function () {
       [["aurora", "linux", "x86"], "/usr/bin/firefox-aurora"],
       [["aurora", "linux", "x86_64"], "/usr/bin/firefox-aurora"],
 
-      [["firefoxdeveloperedition", "linux", "x86"], "/usr/bin/firefox-developer-edition"],
-      [["firefoxdeveloperedition", "linux", "x86_64"], "/usr/bin/firefox-developer-edition"],
+      [["deved", "linux", "x86"], "/usr/bin/firefox-developer-edition"],
+      [["deved", "linux", "x86_64"], "/usr/bin/firefox-developer-edition"],
 
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
@@ -226,6 +226,8 @@ describe("lib/utils", function () {
       [["beta", "darwin", "x86"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
       [["beta", "darwin", "x86_64"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
 
+      [["deved", "darwin", "x86"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
+      [["deved", "darwin", "x86_64"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
       [["firefoxdeveloperedition", "darwin", "x86"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
       [["firefoxdeveloperedition", "darwin", "x86_64"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
 


### PR DESCRIPTION
There is at least one distribution, Arch Linux, which is using `firefox-developer-edition` as an executable name, and this is coherent with the other aliases:

https://github.com/mozilla-jetpack/node-fx-runner/blob/e72b066326e1abd0cd1a4a0d556daf1e6bcc2370/lib/utils.js#L121-L123