### PR TITLE
accurately resolve aliases on macOS

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,9 +25,6 @@ function normalizeBinary (binaryPath, platform, arch) {
     platform = platform || os.platform();
     arch = arch || os.arch();
     binaryPath = binaryPath || process.env.JPM_FIREFOX_BINARY || "firefox";
-    if (binaryPath === "firefoxdeveloperedition") {
-      binaryPath = "deved";
-    }
 
     arch = /64/.test(arch) ? "(64)" : "";
     platform = /darwin/i.test(platform) ? "osx" :
@@ -35,12 +32,16 @@ function normalizeBinary (binaryPath, platform, arch) {
                /linux/i.test(platform) ? "linux" + arch :
                platform;
 
+    if (binaryPath === "deved") {
+      binaryPath = "firefoxdeveloperedition";
+    }
+
     var app = binaryPath.toLowerCase();
 
     if (platform === "osx") {
       var result = null;
       var channelNames = [
-        "firefox", "deved", "beta", "nightly", "aurora"
+        "firefox", "firefoxdeveloperedition", "beta", "nightly", "aurora"
       ];
 
       if (channelNames.indexOf(binaryPath) !== -1) {
@@ -113,22 +114,23 @@ function normalizeBinary (binaryPath, platform, arch) {
 
 normalizeBinary.paths = {
   "firefox on osx": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
-  "beta on osx": "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin",
-  "deved on osx": "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin",
+  // the name of the beta application bundle is the same as the stable one
+  "beta on osx": "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
+  "firefoxdeveloperedition on osx": "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin",
   "aurora on osx": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
-  "nightly on osx": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin",
+  "nightly on osx": "/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin",
 };
 
 normalizeBinary.appNames = {
   "firefox on linux": "firefox",
   "beta on linux": "firefox-beta",
   "aurora on linux": "firefox-aurora",
-  "deved on linux": "firefox-developer-edition",
+  "firefoxdeveloperedition on linux": "firefox-developer-edition",
   "nightly on linux": "firefox-nightly",
   "firefox on windows": "Mozilla Firefox",
   // the default path in the beta installer is the same as the stable one
   "beta on windows": "Mozilla Firefox",
-  "deved on windows": "Firefox Developer Edition",
+  "firefoxdeveloperedition on windows": "Firefox Developer Edition",
   "aurora on windows": "Aurora",
   "nightly on windows": "Nightly"
 };

--- a/test/run/test.utils.js
+++ b/test/run/test.utils.js
@@ -212,8 +212,8 @@ describe("lib/utils", function () {
       [["aurora", "linux", "x86"], "/usr/bin/firefox-aurora"],
       [["aurora", "linux", "x86_64"], "/usr/bin/firefox-aurora"],
 
-      [["deved", "linux", "x86"], "/usr/bin/firefox-developer-edition"],
-      [["deved", "linux", "x86_64"], "/usr/bin/firefox-developer-edition"],
+      [["firefoxdeveloperedition", "linux", "x86"], "/usr/bin/firefox-developer-edition"],
+      [["firefoxdeveloperedition", "linux", "x86_64"], "/usr/bin/firefox-developer-edition"],
 
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
       [["nightly", "linux", "x86_64"], "/usr/bin/firefox-nightly"],
@@ -234,20 +234,21 @@ describe("lib/utils", function () {
       [["firefox", "darwin", "x86"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
       [["firefox", "darwin", "x86_64"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
 
-      [["beta", "darwin", "x86"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
-      [["beta", "darwin", "x86_64"], "/Applications/FirefoxBeta.app/Contents/MacOS/firefox-bin"],
+      [["beta", "darwin", "x86"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
+      [["beta", "darwin", "x86_64"], "/Applications/Firefox.app/Contents/MacOS/firefox-bin"],
 
-      [["deved", "darwin", "x86"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
-      [["deved", "darwin", "x86_64"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
-      [["firefoxdeveloperedition", "darwin", "x86"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
-      [["firefoxdeveloperedition", "darwin", "x86_64"], "/Applications/FirefoxDeveloperEdition.app/Contents/MacOS/firefox-bin"],
+      [["firefoxdeveloperedition", "darwin", "x86"], "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin"],
+      [["firefoxdeveloperedition", "darwin", "x86_64"], "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin"],
+
+      [["deved", "darwin", "x86"], "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin"],
+      [["deved", "darwin", "x86_64"], "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin"],
 
       [["aurora", "darwin", "x86"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
       [["aurora", "darwin", "x86_64"], "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin"],
 
-      [["nightly", "darwin", "x86"], "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin"],
-      [["nightly", "darwin", "x86_64"], "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin"]
-    ].map(function(fixture) {
+      [["nightly", "darwin", "x86"], "/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin"],
+      [["nightly", "darwin", "x86_64"], "/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin"]
+    ].map(function (fixture) {
       var promise = binary.apply(binary, fixture[args]);
       return promise.then(function(actual) {
         expect(actual).to.be.equal(fixture[expected]);
@@ -258,7 +259,7 @@ describe("lib/utils", function () {
 
   describe("findMacAppByChannel", function() {
 
-    var defaultNightly = "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin";
+    var defaultNightly = "/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin";
 
     function spawnSyncStub(stdout) {
       return function() {


### PR DESCRIPTION
This change resolves the issue described in issue #47.

Recent versions of Firefox Developer Edition and Firefox Nightly use spaces in their app names—`Firefox Developer Edition.app` and `Firefox Nightly.app` respectively.

I tried to be sensitive to preserving some backwards compatibility with older names, in case folks are still using them. My local testing (which I acknowledge may miss a historical case I'm not aware of) succeeded in launching the correct version of Firefox when I renamed `/Applications/Firefox Nightly.app` -> `/Applications/FirefoxNightly.app` and `Firefox Developer Edition.app` -> `FirefoxDeveloperEdition.app`.

All of the tests supplied pass for me.

My manual testing included successfully running the following commands with the expected results:

```
./bin/fx-runner -b deved --foreground start
./bin/fx-runner -b firefoxdeveloperedition --foreground start
./bin/fx-runner -b nightly --foreground start
```

Happy to make any changes needed.